### PR TITLE
Añadido API para añadir favoritos y los tests correspondientes.

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -52,3 +52,4 @@ jobs:
         pytest tests/functional/test_reviews.py  --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
         pytest tests/functional/test_session.py  --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
         pytest tests/functional/test_validate.py  --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+        pytest tests/functional/test_favourites.py  --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from resources.validate import Validate
 from resources.profile import Profile
 from resources.orders import Orders, Sales, Purchases
 from resources.reviews import Reviews
+from resources.favourites import Favourites
 
 from models.orders import OrdersModel
 from models.accounts import AccountsModel
@@ -71,6 +72,9 @@ api.add_resource(Logout, '/API/logout/<string:email>')
 api.add_resource(Orders, '/API/order/add/<string:email>')
 api.add_resource(Purchases, '/API/order/purchases/<string:email>')
 api.add_resource(Sales, '/API/order/sales/<string:email>')
+
+# favourites
+api.add_resource(Favourites, '/API/favourites', '/API/favourites/<string:email>')
 
 
 @app.route('/')

--- a/documentation/BDD_API_Documentation.md
+++ b/documentation/BDD_API_Documentation.md
@@ -82,6 +82,45 @@
 
 <br>
 
+###  Modelo de favourites.py (models/favourites.py):
+
+#### Elementos / columnas obligatorios:
+
+- Asumimos que todos los elementos de esta tabla tienen nullable=False
+- La variable que encontramos en favourites.py -> `user_id = db.Column(db.String(50), db.ForeignKey('accounts.email'))`
+  y `product_id = db.Column(db.Integer, db.ForeignKey('products.id'))` es un elemento o columna más de nuestra 
+  tabla favourites que nos servirá para saber de qué usuario son nuestros productos. <br>
+
+| Element     |                 Info                  |
+|-------------|:-------------------------------------:|
+| id          |           Int - primary_key           |
+| user_id     |                String                 |
+| product_id  |                 Int                   |
+| user        |             AccountsModel             |
+| product     |             ProductsModel             |
+
+<br>
+
+###  Modelo de orders.py (models/orders.py):
+
+#### Elementos / columnas obligatorios:
+
+- Asumimos que todos los elementos de esta tabla tienen nullable=False
+- La tabla contiene la información necesaría para hacer una transacción.
+
+| Element                |                 Info                  |
+|------------------------|:-------------------------------------:|
+| id                     |           Int - primary_key           |
+| buyer_id               |                  Int                  |
+| seller_id              |                  Int                  |
+| product_id             |                  Int                  |
+| credit_card            |           Int(Número largo)           |
+| cvc                    |                  Int                  |
+| cc_expiration_date     |        DateTime(validez tarjeta)      |
+| cc_owner               |          String(Dueño tarjeta)        |
+| date                   |         DateTime(Fecha de compra)     |
+<br>
+
 ## API Endpoints:
 
 ### Accounts
@@ -129,3 +168,28 @@
 `Logout, '/API/logout/'string:email''`
 
 - Se encarga de cerrar la sesión del usuario controlando la autenticidad de la cuenta mediante el token del usuario.
+
+
+### Favourites
+
+`/API/favourites`, `/API/favourites/<string:email>`
+
+- Se encarga de añadir productos a la lista de favoritos, eliminar de la lista de favoritos y devolver todos
+  los productos añadido a la lista de favoritos para un usuario en concreto.
+
+### Orders
+`/API/order/add/<string:email>`
+
+- Marca un producto como vendido y también genera una transacción con la información de compra
+
+### Purchases
+
+`/API/order/purchases/<string:email>`
+
+- Devueve el listado de todas las compras del usuario (más recientes primero)
+
+### Sales
+
+`/API/order/sales/<string:email>`
+
+- Devuelve el listado de todas las ventas del usuario (más recientes primero)

--- a/models/favourites.py
+++ b/models/favourites.py
@@ -39,5 +39,10 @@ class FavouritesModel(db.Model):
         return cls.query.filter_by(user_id=user_id).all()
 
     @classmethod
+    def get_fav(cls, user_id, product_id):
+        query = cls.query.filter(cls.user_id == user_id)
+        return query.filter(cls.product_id == product_id).first()
+
+    @classmethod
     def get_all(cls):
         return cls.query.all()

--- a/models/orders.py
+++ b/models/orders.py
@@ -1,5 +1,5 @@
 from db import db
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, desc
 
 
 class OrdersModel(db.Model):
@@ -50,11 +50,13 @@ class OrdersModel(db.Model):
 
     @classmethod
     def get_purchases_by_email(cls, email):  # returns all orders by email
-        return cls.query.filter_by(buyer_id=email).all()
+        query = cls.query.filter_by(buyer_id=email)
+        return query.order_by(desc(cls.date)).all()
 
     @classmethod
     def get_sales_by_email(cls, email):  # returns all products sold by email
-        return cls.query.filter_by(seller_id=email).all()
+        query = cls.query.filter_by(seller_id=email)
+        return query.order_by(desc(cls.date)).all()
 
     def save_to_db(self):
         db.session.add(self)

--- a/resources/accounts.py
+++ b/resources/accounts.py
@@ -1,7 +1,6 @@
 import datetime
 from http import HTTPStatus
 
-import flask
 from flask_restful import Resource, reqparse
 from itsdangerous import URLSafeTimedSerializer
 from sqlalchemy import exc

--- a/resources/favourites.py
+++ b/resources/favourites.py
@@ -1,0 +1,108 @@
+from lock import lock
+from flask_restful import Resource, reqparse
+from http import HTTPStatus
+from sqlalchemy import exc
+import datetime
+
+from models.accounts import *
+from models.favourites import FavouritesModel
+from models.products import ProductsModel
+
+
+class Favourites(Resource):
+
+    @auth.login_required()
+    def get(self, email):
+        with lock.lock:
+            account = AccountsModel.get_by_email(email)
+            # return account if it exists
+            if account is None:  # return error message if order doesn't exist
+                return {'message': 'account with email [{}] does not exist'.format(email)}, HTTPStatus.NOT_FOUND
+            # return error if the account email doesn't match
+            if account.username != g.user.username:
+                return {'message': "Bad authorization user"}, HTTPStatus.BAD_REQUEST
+
+            favourites = FavouritesModel.get_by_email(email)
+            # return favourites if it exists
+            return {"favourites_list": [x.json() for x in favourites]}, HTTPStatus.OK
+
+    @auth.login_required()
+    def post(self):
+        with lock.lock:
+            # get the arguments
+            data = self.get_data()
+
+            account = AccountsModel.get_by_email(data['email'])
+            product = ProductsModel.get_by_id(data['product_id'])
+            # return error if account doesn't exist
+            if account is None:
+                return {'message': "account with email [{}] does not exist".format(data['email'])}, HTTPStatus.CONFLICT
+
+            # return error if the account username doesn't match
+            if account.username != g.user.username:
+                return {'message': "Bad authorization user"}, HTTPStatus.BAD_REQUEST
+
+            # return error if product does not exist
+            if product is None:
+                return {'message': "product with id [{}] doesn't exist".format(data['product_id'])}, HTTPStatus.CONFLICT
+
+            fav = FavouritesModel.get_fav(data['email'], data['product_id'])
+
+            if fav:
+                return {'message': "product with id [{}] is already in your favourite list".
+                        format(data['product_id'])}, HTTPStatus.CONFLICT
+
+            # add new favourite to db
+            try:
+                new_favourite = FavouritesModel(
+                    data['email'],
+                    data['product_id']
+                )
+                new_favourite.save_to_db()
+                return new_favourite.json(), HTTPStatus.OK
+            except exc.SQLAlchemyError:
+                db.session.rollback()  # rollback in case something went wrong
+                return {'message': 'error while adding product to favourites'}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+    @auth.login_required()
+    def delete(self):
+        with lock.lock:
+            # get the arguments
+            data = self.get_data()
+
+            account = AccountsModel.get_by_email(data['email'])
+            product = ProductsModel.get_by_id(data['product_id'])
+            # return error if account doesn't exist
+            if account is None:
+                return {'message': "account with email [{}] does not exist".format(data['email'])}, HTTPStatus.CONFLICT
+
+            # return error if the account username doesn't match
+            if account.username != g.user.username:
+                return {'message': "Bad authorization user"}, HTTPStatus.BAD_REQUEST
+
+            # return error if product does not exist
+            if product is None:
+                return {'message': "product with id [{}] doesn't exist".format(data['product_id'])}, HTTPStatus.CONFLICT
+
+            fav = FavouritesModel.get_fav(data['email'], data['product_id'])
+
+            if not fav:
+                return {'message': "product with id [{}] is not in your favourites list".
+                        format(data['product_id'], data['email'])}, HTTPStatus.CONFLICT
+
+            # delete fav from user
+            try:
+                fav.delete_from_db()
+                return {'message': 'product with id [{}] deleted from favourites'.format(data['product_id'])}, HTTPStatus.OK
+            except exc.SQLAlchemyError:
+                db.session.rollback()  # rollback in case something went wrong
+                return {'message': 'error while deleting product to favourites'}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def get_data(self):
+        parser = reqparse.RequestParser()  # create parameters parser from request
+
+        # define all input parameters need and its type
+        parser.add_argument('email', type=str, required=True, help="This field cannot be left blank")
+        parser.add_argument('product_id', type=int, required=True, help="This field cannot be left blank")
+
+        return parser.parse_args()

--- a/resources/profile.py
+++ b/resources/profile.py
@@ -1,9 +1,9 @@
 from http import HTTPStatus
 from flask_restful import Resource, reqparse
+from sqlalchemy import exc
 
 from db import db
 from models.accounts import AccountsModel, auth, g
-import lock
 
 import datetime
 
@@ -25,29 +25,27 @@ class Profile(Resource):
 
     @auth.login_required
     def put(self, email):
-        with lock.lock:
-            data = self.get_data()
-            for i in data:
-                print(i)
-            user = AccountsModel.get_by_email(email)
-            # return error message if account doesn't exist
-            if user is None:
-                return {'message': 'This email [{}] does not exist'.format(email)}, HTTPStatus.NOT_FOUND
-            if user.username != g.user.username:
-                return {'message': "Bad authorization user"}, HTTPStatus.UNAUTHORIZED
-            if data["name"]:
-                user.name = data["name"]
-            if data["surname"]:
-                user.surname = data["surname"]
-            if data["birthday"]:
-                user.birthday = datetime.date(*map(int, data["birthday"].split('-')))
-                print(user.birthday)
+        data = self.get_data()
+        user = AccountsModel.get_by_email(email)
+        # return error message if account doesn't exist
+        if user is None:
+            return {'message': 'This email [{}] does not exist'.format(email)}, HTTPStatus.NOT_FOUND
+        if user.username != g.user.username:
+            return {'message': "Bad authorization user"}, HTTPStatus.UNAUTHORIZED
+        if data["name"]:
+            user.name = data["name"]
+        if data["surname"]:
+            user.surname = data["surname"]
+        if data["birthday"]:
+            user.birthday = datetime.date(*map(int, data["birthday"].split('-')))
 
+        try:
             db.session.add(user)
             db.session.commit()
-            user = AccountsModel.get_by_email(email)
-            print(user.json())
             return {'message': "Profile updated successfully"}, HTTPStatus.OK
+        except exc.SQLAlchemyError:
+            db.session.rollback()  # rollback in case something went wrong
+            return {'message': 'Error while modifying user information'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
     def get_data(self):
         parser = reqparse.RequestParser()  # create parameters parser from request

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from resources.session import Login, Logout
 from resources.filters import Filter, FilterCategory
 from resources.validate import Validate
 from resources.reviews import Reviews
+from resources.favourites import Favourites
 from db import db
 import random as rand
 from sqlalchemy import exc
@@ -82,6 +83,8 @@ def create_app():
     api.add_resource(Validate, '/API/validation/<string:validation_token>', '/API/validation')
     api.add_resource(Profile, '/API/profile/<string:email>', '/API/profile')
     api.add_resource(Reviews, '/API/reviews/<string:email>', '/API/reviews')
+    # favourites
+    api.add_resource(Favourites, '/API/favourites', '/API/favourites/<string:email>')
 
     # products
     api.add_resource(Product, '/API/product/<string:id>')

--- a/tests/functional/test_favourites.py
+++ b/tests/functional/test_favourites.py
@@ -142,4 +142,3 @@ def test_delete_favourites(client):
         r = client.delete("API/favourites", json=json, headers=headers)
         assert r.status_code == 200
         assert r.json == {'message': "product with id [1] deleted from favourites"}
-

--- a/tests/functional/test_favourites.py
+++ b/tests/functional/test_favourites.py
@@ -1,0 +1,145 @@
+import base64
+
+
+def test_post_favourites(client):
+    with client:
+        # Login
+        json = {'email': 'pepe432@gmail.com', 'username': 'pepeman', 'password': 'pepe123,.'}
+        login = client.post("API/login", json=json)
+        assert login.status_code == 200
+
+        token = login.json
+        headers = {
+            'Authorization': 'Basic {}'.format(
+                base64.b64encode(
+                    '{token}:{password}'.format(
+                        token=token['token'],
+                        password='').encode()
+                ).decode()
+            )
+        }
+        json = {'email': 'pepe433@gmail.com', 'product_id': 99}
+
+        # Test sending request with non-existent user
+        r = client.post("API/favourites", json=json, headers=headers)
+        assert r.status_code == 409
+        assert r.json == {'message': 'account with email [pepe433@gmail.com] does not exist'}
+
+        # Test invalid access with non-matching usernames between current user and request user
+        json['email'] = 'killer23@gmail.com'
+        r = client.post("API/favourites", json=json, headers=headers)
+        assert r.status_code == 400
+        assert r.json == {'message': "Bad authorization user"}
+
+        json['email'] = 'pepe432@gmail.com'
+        # Test sending request with non-existent product
+        r = client.post("API/favourites", json=json, headers=headers)
+        assert r.status_code == 409
+        assert r.json == {'message': "product with id [99] doesn't exist"}
+
+        json['product_id'] = 1
+        # Test adding product to favourite
+        r = client.post("API/favourites", json=json, headers=headers)
+        assert r.status_code == 200
+
+        # Test adding product that's already in favourite
+        r = client.post("API/favourites", json=json, headers=headers)
+        assert r.status_code == 409
+        assert r.json == {'message': "product with id [1] is already in your favourite list"}
+
+
+def test_get_favourites(client):
+    with client:
+        # Login
+        json = {'email': 'pepe432@gmail.com', 'username': 'pepeman', 'password': 'pepe123,.'}
+        login = client.post("API/login", json=json)
+        assert login.status_code == 200
+
+        token = login.json
+        headers = {
+            'Authorization': 'Basic {}'.format(
+                base64.b64encode(
+                    '{token}:{password}'.format(
+                        token=token['token'],
+                        password='').encode()
+                ).decode()
+            )
+        }
+
+        # Test sending request with non-existent user
+        r = client.get("API/favourites/pepe433@gmail.com", headers=headers)
+        assert r.status_code == 404
+        assert r.json == {'message': 'account with email [pepe433@gmail.com] does not exist'}
+
+        # Test invalid access with non-matching usernames between current user and request user
+        r = client.get("API/favourites/killer23@gmail.com", headers=headers)
+        assert r.status_code == 400
+        assert r.json == {'message': "Bad authorization user"}
+
+        # Test retrieving all favourites (no favourites received)
+        r = client.get("API/favourites/pepe432@gmail.com", headers=headers)
+        assert r.status_code == 200
+        assert r.json == {'favourites_list': []}
+
+        json = {'email': 'pepe432@gmail.com', 'product_id': 1}
+
+        # Test add one product to favourite
+        r = client.post("API/favourites", json=json, headers=headers)
+        assert r.status_code == 200
+
+        # Test retrieving all favourites
+        r = client.get("API/favourites/pepe432@gmail.com", headers=headers)
+        assert r.status_code == 200
+        assert r.json['favourites_list'] != []
+
+def test_delete_favourites(client):
+    with client:
+        # Login
+        json = {'email': 'pepe432@gmail.com', 'username': 'pepeman', 'password': 'pepe123,.'}
+        login = client.post("API/login", json=json)
+        assert login.status_code == 200
+
+        token = login.json
+        headers = {
+            'Authorization': 'Basic {}'.format(
+                base64.b64encode(
+                    '{token}:{password}'.format(
+                        token=token['token'],
+                        password='').encode()
+                ).decode()
+            )
+        }
+        json = {'email': 'pepe433@gmail.com', 'product_id': 99}
+
+        # Test sending request with non-existent user
+        r = client.delete("API/favourites", json=json, headers=headers)
+        assert r.status_code == 409
+        assert r.json == {'message': 'account with email [pepe433@gmail.com] does not exist'}
+
+        # Test invalid access with non-matching usernames between current user and request user
+        json['email'] = 'killer23@gmail.com'
+        r = client.delete("API/favourites", json=json, headers=headers)
+        assert r.status_code == 400
+        assert r.json == {'message': "Bad authorization user"}
+
+        json['email'] = 'pepe432@gmail.com'
+        # Test sending request with non-existent product
+        r = client.delete("API/favourites", json=json, headers=headers)
+        assert r.status_code == 409
+        assert r.json == {'message': "product with id [99] doesn't exist"}
+
+        json['product_id'] = 1
+
+        # Test deleting product that's not in favourite
+        r = client.delete("API/favourites", json=json, headers=headers)
+        assert r.status_code == 409
+        assert r.json == {'message': "product with id [1] is not in your favourites list"}
+
+        # Test adding product to favourite and delete it
+        r = client.post("API/favourites", json=json, headers=headers)
+        assert r.status_code == 200
+
+        r = client.delete("API/favourites", json=json, headers=headers)
+        assert r.status_code == 200
+        assert r.json == {'message': "product with id [1] deleted from favourites"}
+

--- a/tests/unit/test_model_favourites.py
+++ b/tests/unit/test_model_favourites.py
@@ -56,3 +56,11 @@ def test_delete_favourite(_app, dummy_favourite):
 
         assert previous == 1
         assert result == 0
+
+
+def test_get_fav(_app, dummy_favourite):
+    with _app.app_context():
+        result = FavouritesModel.get_fav('admin123@gmail.com', 1)
+
+        assert result.user_id == 'admin123@gmail.com'
+        assert result.product_id == 1


### PR DESCRIPTION
closes #208 #211 #205 

Todos los endpoints requieren autentificación previa.

Endpoint para acceder a la API de favoritos: 
* `GET`: /API/favourites/<string:email>
Devuelve todos los productos añadidos a favoritos para un user en concreto
* `POST` y `DELETE`: /API/favourites
POST es usado para añadir un producto a la lista de favoritos
DELETE es usado para eliminar un producto de la lista de favoritos
Desde frontend tendrán que comprobar el estado del variable `liked` o lo que sea que se utiliza para ver si un producto está añadido a favoritos o no, y llamar a `POST` en caso que `liked==FALSE` y `DELETE` en caso que `liked==TRUE`.


Datos necesarios para usar el endpoint:
* `user_id` y `product_id`

También añadido documentación para Orders y Favourites